### PR TITLE
Implemented no duplicate accounts

### DIFF
--- a/src/app/app-home/aaronComponents/search-component/search.component.ts
+++ b/src/app/app-home/aaronComponents/search-component/search.component.ts
@@ -30,7 +30,13 @@ export class SearchComponent {
     if(this.count < 5) {
       this.count++;
       if(name.length === 9) {
-        this.accountsService.addAccount(name);
+        const shouldPortBeLocked = Math.random() > 0.5 ? true : false;
+        const wasNewAccountAdded = this.accountsService.addAccount(name, shouldPortBeLocked);
+        if(!wasNewAccountAdded) {
+          this.snackBar.open(`You are already monitoring BAN ${name}!`, '', {
+            duration: 3000
+          });
+        }
       } else {
         this.snackBar.open('Please enter a valid 9 digit account number!', '', {
           duration: 3000

--- a/src/app/shared/accounts.service.ts
+++ b/src/app/shared/accounts.service.ts
@@ -9,14 +9,31 @@ export class AccountsService {
       constructor(private loggingService: LoggingService) {}
 
 
+      /** I just added this but straight up don't know if I did it right
+       * @description Used to add a BAN to the array of currently monitored accounts
+       * @param name The BAN for this account. Must be a string of 9 digits
+       * @param accountLocked Whether or not the account should be locked.
+       * @returns Returns true if the account was successfully added to the the list of monitored 
+       */
+      addAccount(name: string, accountLocked: boolean): boolean {
+        let foundMatch: boolean = false;
+        for(let i = 0; i < this.accounts.length; i++) { 
+          if(this.accounts[i].name === name) {
+            foundMatch = true;
+            break;
+          }
+        }
+        if(!foundMatch) { // only adds the account of a matching BAN was not found
+          this.accounts.push({
+            name: name, 
+            status: (accountLocked ? 'locked' : 'unlocked')
+          });
+          this.loggingService.logNewBan(name);
+          this.count++;
+        }
 
-      addAccount(name: string) {
-        this.accounts.push({
-          name: name, 
-          status: 'unlocked'
-        });
-        this.loggingService.logNewBan(name);
-        this.count++
+        // Returns true if a new account was added to the account array
+        return !foundMatch;
       }
 
       updateStatus(id: number, status: string) {


### PR DESCRIPTION
Implemented duplicate ban checker in addAccount method of the accounts.service.ts file, as well as added a snackBar notice in search.component.ts for when the user attempts to add a duplicate ban. Also allowed for addAccount to be passed a boolean to tell whether the port should start locked or unlocked, and added a 50/50 randomizer in search.component to randomly pick the starting state of the port.